### PR TITLE
Bump Node.js to version 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {
-    "node": ">=0.8"
+    "node": ">=4.0"
   },
   "scripts": {
     "pretest": "./node_modules/.bin/jshint --config ./.jshintrc lib test",


### PR DESCRIPTION
### Description

This PR bumps node engine version from 0.8 to 4.0 minimum.