### PR TITLE
Change refresh_token grant to validate the request scope and use it if valid

### DIFF
--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -8,6 +8,7 @@ var AbstractGrantType = require('./abstract-grant-type');
 var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidGrantError = require('../errors/invalid-grant-error');
 var InvalidRequestError = require('../errors/invalid-request-error');
+var InvalidScopeError = require('../errors/invalid-scope-error');
 var Promise = require('bluebird');
 var ServerError = require('../errors/server-error');
 var is = require('../validator/is');
@@ -68,7 +69,9 @@ RefreshTokenGrantType.prototype.handle = function(request, client) {
       return this.revokeToken(request, token);
     })
     .then(function(token) {
-      return this.saveToken(request, token.user, client, token.scope);
+      var scope = this.validateScope(request, token);
+
+      return this.saveToken(request, token.user, client, scope);
     });
 };
 
@@ -166,6 +169,25 @@ RefreshTokenGrantType.prototype.saveToken = function(request, user, client, scop
 
       return this.model.saveToken({ client, token, user }, { request });
     });
+};
+
+/**
+ * Validate scope.
+ */
+
+RefreshTokenGrantType.prototype.validateScope = function (request, token) {
+  var requestScope = this.getScope(request);
+  var scope = token.scope;
+
+  if (requestScope) {
+    if (!this.model.validateScope({ scope: requestScope, token }, { request })) {
+      throw new InvalidScopeError('The requested scope is invalid');
+    }
+
+    scope = requestScope;
+  }
+
+  return scope;
 };
 
 /**


### PR DESCRIPTION
Change refresh_token grant to validate the request scope when it's provided.
If the scope is valid new token will have that scope.
If it's invalid, an error is thrown.
If no scope is provided in the request, the new token will have the same scope as the old token.